### PR TITLE
Fix arm/aarch64 URL links

### DIFF
--- a/downloads/allwinner/index.html
+++ b/downloads/allwinner/index.html
@@ -3,8 +3,6 @@ layout: download
 title: LibreELEC Allwinner
 description: Allwinner based devices
 ---
-<!-- project arch -->
-{% assign arch = "arm" %}
 
 <!-- LE 12.0 -->
 <div class="card mb-2">
@@ -21,54 +19,54 @@ description: Allwinner based devices
 <div class="card mb-4">
   <h5 class="card-header toc">Allwinner A64</h5>
   <div class="card-body">
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_12_0 device="orangepi-win" device_name="Orange Pi Win" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_12_0 device="pine64" device_name="Pine64" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_12_0 device="pine64-lts" device_name="Pine64 LTS" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_12_0 device="pine64-plus" device_name="Pine64 Plus" %}
+    {% include dl_links.html project="A64" arch=aarch64 version=site.le_version_download_12_0 device="orangepi-win" device_name="Orange Pi Win" %}
+    {% include dl_links.html project="A64" arch=aarch64 version=site.le_version_download_12_0 device="pine64" device_name="Pine64" %}
+    {% include dl_links.html project="A64" arch=aarch64 version=site.le_version_download_12_0 device="pine64-lts" device_name="Pine64 LTS" %}
+    {% include dl_links.html project="A64" arch=aarch64 version=site.le_version_download_12_0 device="pine64-plus" device_name="Pine64 Plus" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H3</h5>
   <div class="card-body">
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="bananapi-m2p" device_name="Banana Pi M2 Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="beelink-x2" device_name="Beelink X2" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="libretech-h3" device_name="Libretech H3" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="nanopi-m1" device_name="NanoPi M1" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="orangepi-2" device_name="Orange Pi 2" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="orangepi-pc" device_name="Orange Pi PC" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="orangepi-pc-plus" device_name="Orange Pi PC Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="orangepi-plus" device_name="Orange Pi Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_12_0 device="orangepi-plus2e" device_name="Orange Pi Plus 2E" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="bananapi-m2p" device_name="Banana Pi M2 Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="beelink-x2" device_name="Beelink X2" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="libretech-h3" device_name="Libretech H3" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="nanopi-m1" device_name="NanoPi M1" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="orangepi-2" device_name="Orange Pi 2" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="orangepi-pc" device_name="Orange Pi PC" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="orangepi-pc-plus" device_name="Orange Pi PC Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="orangepi-plus" device_name="Orange Pi Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_12_0 device="orangepi-plus2e" device_name="Orange Pi Plus 2E" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H5</h5>
   <div class="card-body">
-    {% include dl_links.html project="H5" arch=arch version=site.le_version_download_12_0 device="orangepi-pc2" device_name="Orange Pi PC2" %}
-    {% include dl_links.html project="H5" arch=arch version=site.le_version_download_12_0 device="tritium-h5" device_name="Tritium H5" %}
+    {% include dl_links.html project="H5" arch=aarch64 version=site.le_version_download_12_0 device="orangepi-pc2" device_name="Orange Pi PC2" %}
+    {% include dl_links.html project="H5" arch=aarch64 version=site.le_version_download_12_0 device="tritium-h5" device_name="Tritium H5" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H6</h5>
   <div class="card-body">
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="beelink-gs1" device_name="Beelink GS1" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="orangepi-3" device_name="Orange Pi 3" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="orangepi-3-lts" device_name="Orange Pi 3 LTS" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="orangepi-lite2" device_name="Orange Pi Lite 2" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="orangepi-one-plus" device_name="Orange Pi One Plus" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="pine-h64" device_name="Pine H64 Model A" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="pine-h64-model-b" device_name="Pine H64 Model B" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_12_0 device="tanix-tx6" device_name="Tanix TX6" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="beelink-gs1" device_name="Beelink GS1" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="orangepi-3" device_name="Orange Pi 3" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="orangepi-3-lts" device_name="Orange Pi 3 LTS" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="orangepi-lite2" device_name="Orange Pi Lite 2" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="orangepi-one-plus" device_name="Orange Pi One Plus" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="pine-h64" device_name="Pine H64 Model A" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="pine-h64-model-b" device_name="Pine H64 Model B" %}
+    {% include dl_links.html project="H6" arch=aarch64 version=site.le_version_download_12_0 device="tanix-tx6" device_name="Tanix TX6" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header">Allwinner R40</h5>
   <div class="card-body">
-    {% include dl_links.html project="R40" arch=arch version=site.le_version_download_12_0 device="bananapi-m2u" device_name="Banana Pi M2 Ultra" %}
+    {% include dl_links.html project="R40" arch=arm version=site.le_version_download_12_0 device="bananapi-m2u" device_name="Banana Pi M2 Ultra" %}
   </div>
 </div>
 
@@ -87,54 +85,54 @@ description: Allwinner based devices
 <div class="card mb-4">
   <h5 class="card-header toc">Allwinner A64</h5>
   <div class="card-body">
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_11_0 device="orangepi-win" device_name="Orange Pi Win" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_11_0 device="pine64" device_name="Pine64" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_11_0 device="pine64-lts" device_name="Pine64 LTS" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_11_0 device="pine64-plus" device_name="Pine64 Plus" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_11_0 device="orangepi-win" device_name="Orange Pi Win" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_11_0 device="pine64" device_name="Pine64" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_11_0 device="pine64-lts" device_name="Pine64 LTS" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_11_0 device="pine64-plus" device_name="Pine64 Plus" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H3</h5>
   <div class="card-body">
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="bananapi-m2p" device_name="Banana Pi M2 Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="beelink-x2" device_name="Beelink X2" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="libretech-h3" device_name="Libretech H3" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="nanopi-m1" device_name="NanoPi M1" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="orangepi-2" device_name="Orange Pi 2" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="orangepi-pc" device_name="Orange Pi PC" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="orangepi-pc-plus" device_name="Orange Pi PC Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="orangepi-plus" device_name="Orange Pi Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_11_0 device="orangepi-plus2e" device_name="Orange Pi Plus 2E" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="bananapi-m2p" device_name="Banana Pi M2 Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="beelink-x2" device_name="Beelink X2" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="libretech-h3" device_name="Libretech H3" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="nanopi-m1" device_name="NanoPi M1" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="orangepi-2" device_name="Orange Pi 2" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="orangepi-pc" device_name="Orange Pi PC" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="orangepi-pc-plus" device_name="Orange Pi PC Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="orangepi-plus" device_name="Orange Pi Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_11_0 device="orangepi-plus2e" device_name="Orange Pi Plus 2E" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H5</h5>
   <div class="card-body">
-    {% include dl_links.html project="H5" arch=arch version=site.le_version_download_11_0 device="orangepi-pc2" device_name="Orange Pi PC2" %}
-    {% include dl_links.html project="H5" arch=arch version=site.le_version_download_11_0 device="tritium-h5" device_name="Tritium H5" %}
+    {% include dl_links.html project="H5" arch=arm version=site.le_version_download_11_0 device="orangepi-pc2" device_name="Orange Pi PC2" %}
+    {% include dl_links.html project="H5" arch=arm version=site.le_version_download_11_0 device="tritium-h5" device_name="Tritium H5" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H6</h5>
   <div class="card-body">
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="beelink-gs1" device_name="Beelink GS1" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="orangepi-3" device_name="Orange Pi 3" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="orangepi-3-lts" device_name="Orange Pi 3 LTS" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="orangepi-lite2" device_name="Orange Pi Lite 2" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="orangepi-one-plus" device_name="Orange Pi One Plus" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="pine-h64" device_name="Pine H64 Model A" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="pine-h64-model-b" device_name="Pine H64 Model B" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_11_0 device="tanix-tx6" device_name="Tanix TX6" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="beelink-gs1" device_name="Beelink GS1" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="orangepi-3" device_name="Orange Pi 3" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="orangepi-3-lts" device_name="Orange Pi 3 LTS" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="orangepi-lite2" device_name="Orange Pi Lite 2" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="orangepi-one-plus" device_name="Orange Pi One Plus" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="pine-h64" device_name="Pine H64 Model A" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="pine-h64-model-b" device_name="Pine H64 Model B" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_11_0 device="tanix-tx6" device_name="Tanix TX6" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header">Allwinner R40</h5>
   <div class="card-body">
-    {% include dl_links.html project="R40" arch=arch version=site.le_version_download_11_0 device="bananapi-m2u" device_name="Banana Pi M2 Ultra" %}
+    {% include dl_links.html project="R40" arch=arm version=site.le_version_download_11_0 device="bananapi-m2u" device_name="Banana Pi M2 Ultra" %}
   </div>
 </div>
 
@@ -153,52 +151,52 @@ description: Allwinner based devices
 <div class="card mb-4">
   <h5 class="card-header toc">Allwinner A64</h5>
   <div class="card-body">
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_10_0 device="orangepi-win" device_name="Orange Pi Win" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_10_0 device="pine64" device_name="Pine64" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_10_0 device="pine64-lts" device_name="Pine64 LTS" %}
-    {% include dl_links.html project="A64" arch=arch version=site.le_version_download_10_0 device="pine64-plus" device_name="Pine64 Plus" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_10_0 device="orangepi-win" device_name="Orange Pi Win" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_10_0 device="pine64" device_name="Pine64" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_10_0 device="pine64-lts" device_name="Pine64 LTS" %}
+    {% include dl_links.html project="A64" arch=arm version=site.le_version_download_10_0 device="pine64-plus" device_name="Pine64 Plus" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H3</h5>
   <div class="card-body">
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="bananapi-m2p" device_name="Banana Pi M2 Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="beelink-x2" device_name="Beelink X2" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="libretech-h3" device_name="Libretech H3" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="nanopi-m1" device_name="NanoPi M1" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="orangepi-2" device_name="Orange Pi 2" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="orangepi-pc" device_name="Orange Pi PC" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="orangepi-pc-plus" device_name="Orange Pi PC Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="orangepi-plus" device_name="Orange Pi Plus" %}
-    {% include dl_links.html project="H3" arch=arch version=site.le_version_download_10_0 device="orangepi-plus2e" device_name="Orange Pi Plus 2E" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="bananapi-m2p" device_name="Banana Pi M2 Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="beelink-x2" device_name="Beelink X2" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="libretech-h3" device_name="Libretech H3" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="nanopi-m1" device_name="NanoPi M1" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="orangepi-2" device_name="Orange Pi 2" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="orangepi-pc" device_name="Orange Pi PC" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="orangepi-pc-plus" device_name="Orange Pi PC Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="orangepi-plus" device_name="Orange Pi Plus" %}
+    {% include dl_links.html project="H3" arch=arm version=site.le_version_download_10_0 device="orangepi-plus2e" device_name="Orange Pi Plus 2E" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H5</h5>
   <div class="card-body">
-    {% include dl_links.html project="H5" arch=arch version=site.le_version_download_10_0 device="orangepi-pc2" device_name="Orange Pi PC2" %}
-    {% include dl_links.html project="H5" arch=arch version=site.le_version_download_10_0 device="tritium-h5" device_name="Tritium H5" %}
+    {% include dl_links.html project="H5" arch=arm version=site.le_version_download_10_0 device="orangepi-pc2" device_name="Orange Pi PC2" %}
+    {% include dl_links.html project="H5" arch=arm version=site.le_version_download_10_0 device="tritium-h5" device_name="Tritium H5" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header">Allwinner H6</h5>
   <div class="card-body">
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="beelink-gs1" device_name="Beelink GS1" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="orangepi-3" device_name="Orange Pi 3" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="orangepi-lite2" device_name="Orange Pi Lite 2" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="orangepi-one-plus" device_name="Orange Pi One Plus" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="pine-h64" device_name="Pine H64 Model A" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="pine-h64-model-b" device_name="Pine H64 Model B" %}
-    {% include dl_links.html project="H6" arch=arch version=site.le_version_download_10_0 device="tanix-tx6" device_name="Tanix TX6" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="beelink-gs1" device_name="Beelink GS1" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="orangepi-3" device_name="Orange Pi 3" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="orangepi-lite2" device_name="Orange Pi Lite 2" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="orangepi-one-plus" device_name="Orange Pi One Plus" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="pine-h64" device_name="Pine H64 Model A" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="pine-h64-model-b" device_name="Pine H64 Model B" %}
+    {% include dl_links.html project="H6" arch=arm version=site.le_version_download_10_0 device="tanix-tx6" device_name="Tanix TX6" %}
   </div>
 </div>
 
 <div class="card">
   <h5 class="card-header">Allwinner R40</h5>
   <div class="card-body">
-    {% include dl_links.html project="R40" arch=arch version=site.le_version_download_10_0 device="bananapi-m2u" device_name="Banana Pi M2 Ultra" %}
+    {% include dl_links.html project="R40" arch=arm version=site.le_version_download_10_0 device="bananapi-m2u" device_name="Banana Pi M2 Ultra" %}
   </div>
 </div>

--- a/downloads/amlogic/index.html
+++ b/downloads/amlogic/index.html
@@ -4,9 +4,6 @@ title: LibreELEC Amlogic
 description: Amlogic based devices
 ---
 
-<!-- project arch -->
-{% assign arch = "arm" %}
-
 <!-- LE 12.0 -->
 <div class="card mb-2">
   <h5 class="card-header text-white bg-danger">Latest Beta Version ({{ site.release_date_le_12_0 }})</h5>
@@ -24,29 +21,29 @@ description: Amlogic based devices
 <div class="card mb-4">
   <h5 class="card-header toc">Android Boxes (SD Card Boot)</h5>
   <div class="card-body">
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="box" device_name="Generic Box Image" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="box" device_name="Generic Box Image" %}
   </div>
 </div>
 
 <div class="card mb-4">
   <h5 class="card-header toc">SBC Boards (SD Card or eMMC Boot)</h5>
   <div class="card-body">
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="bananapi-m5" device_name="Banana Pi BPI-M5" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="nanopi-k2" device_name="NanoPi K2" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="khadas-vim" device_name="Khadas VIM" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="khadas-vim2" device_name="Khadas VIM2" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="khadas-vim3" device_name="Khadas VIM3" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="khadas-vim3l" device_name="Khadas VIM3L" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="lafrite" device_name="AML-S805X-AC (LaFrite)" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="lepotato" device_name="AML-S905X-CC (LePotato)" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="odroid-c2" device_name="ODROID C2" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="odroid-c4" device_name="ODROID C4" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="odroid-hc4" device_name="ODROID HC4" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="odroid-n2" device_name="ODROID N2/N2+" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="radxa-zero" device_name="Radxa Zero" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="radxa-zero2" device_name="Radxa Zero2" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="wetek-hub" device_name="WeTek Hub" %}
-    {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_12_0 device="wetek-play2" device_name="WeTek Play2" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="bananapi-m5" device_name="Banana Pi BPI-M5" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="nanopi-k2" device_name="NanoPi K2" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="khadas-vim" device_name="Khadas VIM" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="khadas-vim2" device_name="Khadas VIM2" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="khadas-vim3" device_name="Khadas VIM3" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="khadas-vim3l" device_name="Khadas VIM3L" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="lafrite" device_name="AML-S805X-AC (LaFrite)" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="lepotato" device_name="AML-S905X-CC (LePotato)" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="odroid-c2" device_name="ODROID C2" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="odroid-c4" device_name="ODROID C4" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="odroid-hc4" device_name="ODROID HC4" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="odroid-n2" device_name="ODROID N2/N2+" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="radxa-zero" device_name="Radxa Zero" %}
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="radxa-zero2" device_name="Radxa Zero2" %}
+    <!-- {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="wetek-hub" device_name="WeTek Hub" %} -->
+    {% include dl_links.html project="AMLGX" arch=aarch64 version=site.le_version_download_12_0 device="wetek-play2" device_name="WeTek Play2" %}
   </div>
 </div>
 
@@ -67,29 +64,29 @@ description: Amlogic based devices
   <div class="card mb-4">
     <h5 class="card-header toc">Android Boxes (SD Card Boot)</h5>
     <div class="card-body">
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="box" device_name="Generic Box Image" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="box" device_name="Generic Box Image" %}
     </div>
   </div>
 
   <div class="card mb-4">
     <h5 class="card-header toc">SBC Boards (SD Card or eMMC Boot)</h5>
     <div class="card-body">
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="bananapi-m5" device_name="Banana Pi BPI-M5" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="nanopi-k2" device_name="NanoPi K2" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="khadas-vim" device_name="Khadas VIM" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="khadas-vim2" device_name="Khadas VIM2" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="khadas-vim3" device_name="Khadas VIM3" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="khadas-vim3l" device_name="Khadas VIM3L" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="lafrite" device_name="AML-S805X-AC (LaFrite)" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="lepotato" device_name="AML-S905X-CC (LePotato)" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="odroid-c2" device_name="ODROID C2" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="odroid-c4" device_name="ODROID C4" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="odroid-hc4" device_name="ODROID HC4" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="odroid-n2" device_name="ODROID N2/N2+" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="radxa-zero" device_name="Radxa Zero" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="radxa-zero2" device_name="Radxa Zero2" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="wetek-hub" device_name="WeTek Hub" %}
-      {% include dl_links.html project="AMLGX" arch=arch version=site.le_version_download_11_0 device="wetek-play2" device_name="WeTek Play2" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="bananapi-m5" device_name="Banana Pi BPI-M5" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="nanopi-k2" device_name="NanoPi K2" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="khadas-vim" device_name="Khadas VIM" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="khadas-vim2" device_name="Khadas VIM2" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="khadas-vim3" device_name="Khadas VIM3" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="khadas-vim3l" device_name="Khadas VIM3L" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="lafrite" device_name="AML-S805X-AC (LaFrite)" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="lepotato" device_name="AML-S905X-CC (LePotato)" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="odroid-c2" device_name="ODROID C2" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="odroid-c4" device_name="ODROID C4" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="odroid-hc4" device_name="ODROID HC4" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="odroid-n2" device_name="ODROID N2/N2+" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="radxa-zero" device_name="Radxa Zero" %}
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="radxa-zero2" device_name="Radxa Zero2" %}
+      <!-- {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="wetek-hub" device_name="WeTek Hub" %} -->
+      {% include dl_links.html project="AMLGX" arch=arm version=site.le_version_download_11_0 device="wetek-play2" device_name="WeTek Play2" %}
     </div>
   </div>
 
@@ -108,18 +105,18 @@ description: Amlogic based devices
 <div class="card mb-4">
     <h5 class="card-header toc">Wetek</h5>
     <div class="card-body">
-        {% include dl_links.html project="WeTek_Core" arch=arch version=site.le_version_download_9_0 device_name="WeTek Core" %}
-        {% include dl_links.html project="WeTek_Hub" arch=arch version=site.le_version_download_9_0 device_name="WeTek Hub" %}
-        {% include dl_links.html project="WeTek_Play" arch=arch version=site.le_version_download_9_0 device_name="WeTek Play" %}
-        {% include dl_links.html project="WeTek_Play_2" arch=arch version=site.le_version_download_9_0 device_name="WeTek Play2" %}
+        {% include dl_links.html project="WeTek_Core" arch=arm version=site.le_version_download_9_0 device_name="WeTek Core" %}
+        {% include dl_links.html project="WeTek_Hub" arch=arm version=site.le_version_download_9_0 device_name="WeTek Hub" %}
+        {% include dl_links.html project="WeTek_Play" arch=arm version=site.le_version_download_9_0 device_name="WeTek Play" %}
+        {% include dl_links.html project="WeTek_Play_2" arch=arm version=site.le_version_download_9_0 device_name="WeTek Play2" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Amlogic S905</h5>
     <div class="card-body">
-        {% include dl_links.html project="KVIM" arch=arch version=site.le_version_download_9_0 device_name="Khadas VIM" %}
-        {% include dl_links.html project="LePotato" arch=arch version=site.le_version_download_9_0 device_name="LePotato" %}
-        {% include dl_links.html project="Odroid_C2" arch=arch version=site.le_version_download_9_0 device_name="Odroid C2" %}
+        {% include dl_links.html project="KVIM" arch=arm version=site.le_version_download_9_0 device_name="Khadas VIM" %}
+        {% include dl_links.html project="LePotato" arch=arm version=site.le_version_download_9_0 device_name="LePotato" %}
+        {% include dl_links.html project="Odroid_C2" arch=arm version=site.le_version_download_9_0 device_name="Odroid C2" %}
     </div>
 </div>

--- a/downloads/raspberry/index.html
+++ b/downloads/raspberry/index.html
@@ -17,21 +17,21 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi5</h5>
+  <h5 class="card-header toc">Raspberry Pi 5</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi5" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 5" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi4</h5>
+  <h5 class="card-header toc">Raspberry Pi 4</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi400</h5>
+  <h5 class="card-header toc">Raspberry Pi 400</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 4" %}
   </div>
@@ -45,14 +45,14 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry 3</h5>
+  <h5 class="card-header toc">Raspberry Pi 3</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_12_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry 2</h5>
+  <h5 class="card-header toc">Raspberry Pi 2</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_12_0 device_name="RPi 2" %}
   </div>
@@ -71,21 +71,21 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi5</h5>
+  <h5 class="card-header toc">Raspberry Pi 5</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi5" arch=arm version=site.le_version_download_11_0 device_name="RPi 5" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi4</h5>
+  <h5 class="card-header toc">Raspberry Pi 4</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_11_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi400</h5>
+  <h5 class="card-header toc">Raspberry Pi 400</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_11_0 device_name="RPi 4" %}
   </div>
@@ -99,14 +99,14 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry 3</h5>
+  <h5 class="card-header toc">Raspberry Pi 3</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_11_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry 2</h5>
+  <h5 class="card-header toc">Raspberry Pi 2</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_11_0 device_name="RPi 2" %}
   </div>
@@ -125,14 +125,14 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi4</h5>
+  <h5 class="card-header toc">Raspberry Pi 4</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_10_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi400</h5>
+  <h5 class="card-header toc">Raspberry Pi 400</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_10_0 device_name="RPi 4" %}
   </div>
@@ -146,21 +146,21 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry 3</h5>
+  <h5 class="card-header toc">Raspberry Pi 3</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_10_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry 2</h5>
+  <h5 class="card-header toc">Raspberry Pi 2</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_10_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">RPi Zero, RPi 1</h5>
+  <h5 class="card-header toc">Raspberry Pi Zero/1</h5>
   <div class="card-body">
     There are no LE 10.0 versions for RPi 0-1.
   </div>
@@ -179,35 +179,35 @@ description: Raspberry Pi boards and devices
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi4</h5>
+  <h5 class="card-header toc">Raspberry Pi 4</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_rpi_9_2 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi3</h5>
+  <h5 class="card-header toc">Raspberry Pi 3</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_rpi_9_2 device_name="RPi 3" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi2</h5>
+  <h5 class="card-header toc">Raspberry Pi 2</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_rpi_9_2 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Pi1</h5>
+  <h5 class="card-header toc">Raspberry Pi 1</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi" arch=arm version=site.le_version_download_9_2 device_name="RPi 1" %}
   </div>
 </div>
 
 <div class="card mb-3">
-  <h5 class="card-header toc">Raspberry Zero</h5>
+  <h5 class="card-header toc">Raspberry Pi Zero</h5>
   <div class="card-body">
     {% include dl_links.html project="RPi" arch=arm version=site.le_version_download_9_2 device_name="RPi Zero" %}
   </div>

--- a/downloads/raspberry/index.html
+++ b/downloads/raspberry/index.html
@@ -3,8 +3,6 @@ layout: download
 title: LibreELEC Raspberry
 description: Raspberry Pi boards and devices
 ---
-<!-- project arch -->
-{% assign arch = "arm" %}
 
 <!-- LE 12.0 -->
 <div class="card mb-2">
@@ -21,42 +19,42 @@ description: Raspberry Pi boards and devices
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi5</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi5" arch=arch version=site.le_version_download_12_0 device_name="RPi 5" %}
+    {% include dl_links.html project="RPi5" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 5" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_12_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi400</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_12_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry CM4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_12_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=aarch64 version=site.le_version_download_12_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry 3</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_12_0 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_12_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry 2</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_12_0 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_12_0 device_name="RPi 2" %}
   </div>
 </div>
 
@@ -75,42 +73,42 @@ description: Raspberry Pi boards and devices
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi5</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi5" arch=arch version=site.le_version_download_11_0 device_name="RPi 5" %}
+    {% include dl_links.html project="RPi5" arch=arm version=site.le_version_download_11_0 device_name="RPi 5" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_11_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_11_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi400</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_11_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_11_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry CM4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_11_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_11_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry 3</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_11_0 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_11_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry 2</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_11_0 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_11_0 device_name="RPi 2" %}
   </div>
 </div>
 
@@ -129,35 +127,35 @@ description: Raspberry Pi boards and devices
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_10_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_10_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi400</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_10_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_10_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry CM4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_10_0 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_10_0 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry 3</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_10_0 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_10_0 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry 2</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_10_0 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_10_0 device_name="RPi 2" %}
   </div>
 </div>
 
@@ -183,34 +181,34 @@ description: Raspberry Pi boards and devices
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi4</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi4" arch=arch version=site.le_version_download_rpi_9_2 device_name="RPi 4" %}
+    {% include dl_links.html project="RPi4" arch=arm version=site.le_version_download_rpi_9_2 device_name="RPi 4" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi3</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_rpi_9_2 device_name="RPi 3" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_rpi_9_2 device_name="RPi 3" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi2</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi2" arch=arch version=site.le_version_download_rpi_9_2 device_name="RPi 2" %}
+    {% include dl_links.html project="RPi2" arch=arm version=site.le_version_download_rpi_9_2 device_name="RPi 2" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Pi1</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi" arch=arch version=site.le_version_download_9_2 device_name="RPi 1" %}
+    {% include dl_links.html project="RPi" arch=arm version=site.le_version_download_9_2 device_name="RPi 1" %}
   </div>
 </div>
 
 <div class="card mb-3">
   <h5 class="card-header toc">Raspberry Zero</h5>
   <div class="card-body">
-    {% include dl_links.html project="RPi" arch=arch version=site.le_version_download_9_2 device_name="RPi Zero" %}
+    {% include dl_links.html project="RPi" arch=arm version=site.le_version_download_9_2 device_name="RPi Zero" %}
   </div>
 </div>

--- a/downloads/rockchip/index.html
+++ b/downloads/rockchip/index.html
@@ -3,8 +3,6 @@ layout: download
 title: LibreELEC Rockchip
 description: Rockchip based devices
 ---
-<!-- project arch -->
-{% assign arch = "arm" %}
 
 <!-- LE 12.0 -->
 <div class="card mb-2">
@@ -21,38 +19,38 @@ description: Rockchip based devices
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3288</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3288" arch=arch version=site.le_version_download_12_0 device="tinker" device_name="ASUS Tinker Board" %}
-        {% include dl_links.html project="RK3288" arch=arch version=site.le_version_download_12_0 device="miqi" device_name="Mqmaker MiQi" %}
+        {% include dl_links.html project="RK3288" arch=arm version=site.le_version_download_12_0 device="tinker" device_name="ASUS Tinker Board" %}
+        {% include dl_links.html project="RK3288" arch=arm version=site.le_version_download_12_0 device="miqi" device_name="Mqmaker MiQi" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3328</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_12_0 device="a1" device_name="Beelink A1 TV BOX" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_12_0 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_12_0 device="rock64" device_name="PINE64 ROCK64" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_12_0 device="rock64" device_name="Popcorn Hour Transformer" %}
+        {% include dl_links.html project="RK3328" arch=aarch64 version=site.le_version_download_12_0 device="a1" device_name="Beelink A1 TV BOX" %}
+        {% include dl_links.html project="RK3328" arch=aarch64 version=site.le_version_download_12_0 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
+        {% include dl_links.html project="RK3328" arch=aarch64 version=site.le_version_download_12_0 device="rock64" device_name="PINE64 ROCK64" %}
+        {% include dl_links.html project="RK3328" arch=aarch64 version=site.le_version_download_12_0 device="rock64" device_name="Popcorn Hour Transformer" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3399</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="rock960" device_name="96rocks ROCK960" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="nanopc-t4" device_name="FriendlyARM NanoPC-T4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="nanopi-m4" device_name="FriendlyARM NanoPi M4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="hugsun-x99" device_name="Hugsun X99 TV BOX" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="khadas-edge" device_name="Khadas Edge" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="orangepi" device_name="Orange Pi RK3399" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="rockpro64" device_name="PINE64 RockPro64" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="roc-pc" device_name="ROC RK3399 PC" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="roc-pc-plus" device_name="ROC RK3399 PC Plus" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4A Plus" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4B Plus" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="rock-pi-n10" device_name="Radxa ROCK Pi N10" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_12_0 device="sapphire" device_name="Rockchip Sapphire Board" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="rock960" device_name="96rocks ROCK960" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="nanopc-t4" device_name="FriendlyARM NanoPC-T4" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="nanopi-m4" device_name="FriendlyARM NanoPi M4" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="hugsun-x99" device_name="Hugsun X99 TV BOX" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="khadas-edge" device_name="Khadas Edge" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="orangepi" device_name="Orange Pi RK3399" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="rockpro64" device_name="PINE64 RockPro64" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="roc-pc" device_name="ROC RK3399 PC" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="roc-pc-plus" device_name="ROC RK3399 PC Plus" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4A Plus" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4B Plus" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="rock-pi-n10" device_name="Radxa ROCK Pi N10" %}
+        {% include dl_links.html project="RK3399" arch=aarch64 version=site.le_version_download_12_0 device="sapphire" device_name="Rockchip Sapphire Board" %}
     </div>
 </div>
 
@@ -71,38 +69,38 @@ description: Rockchip based devices
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3288</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3288" arch=arch version=site.le_version_download_11_0 device="tinker" device_name="ASUS Tinker Board" %}
-        {% include dl_links.html project="RK3288" arch=arch version=site.le_version_download_11_0 device="miqi" device_name="Mqmaker MiQi" %}
+        {% include dl_links.html project="RK3288" arch=arm version=site.le_version_download_11_0 device="tinker" device_name="ASUS Tinker Board" %}
+        {% include dl_links.html project="RK3288" arch=arm version=site.le_version_download_11_0 device="miqi" device_name="Mqmaker MiQi" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3328</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_11_0 device="a1" device_name="Beelink A1 TV BOX" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_11_0 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_11_0 device="rock64" device_name="PINE64 ROCK64" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_11_0 device="rock64" device_name="Popcorn Hour Transformer" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_11_0 device="a1" device_name="Beelink A1 TV BOX" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_11_0 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_11_0 device="rock64" device_name="PINE64 ROCK64" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_11_0 device="rock64" device_name="Popcorn Hour Transformer" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3399</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="rock960" device_name="96rocks ROCK960" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="nanopc-t4" device_name="FriendlyARM NanoPC-T4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="nanopi-m4" device_name="FriendlyARM NanoPi M4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="hugsun-x99" device_name="Hugsun X99 TV BOX" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="khadas-edge" device_name="Khadas Edge" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="orangepi" device_name="Orange Pi RK3399" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="rockpro64" device_name="PINE64 RockPro64" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="roc-pc" device_name="ROC RK3399 PC" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="roc-pc-plus" device_name="ROC RK3399 PC Plus" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4A Plus" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4B Plus" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="rock-pi-n10" device_name="Radxa ROCK Pi N10" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_11_0 device="sapphire" device_name="Rockchip Sapphire Board" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="rock960" device_name="96rocks ROCK960" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="nanopc-t4" device_name="FriendlyARM NanoPC-T4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="nanopi-m4" device_name="FriendlyARM NanoPi M4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="hugsun-x99" device_name="Hugsun X99 TV BOX" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="khadas-edge" device_name="Khadas Edge" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="orangepi" device_name="Orange Pi RK3399" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="rockpro64" device_name="PINE64 RockPro64" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="roc-pc" device_name="ROC RK3399 PC" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="roc-pc-plus" device_name="ROC RK3399 PC Plus" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4A Plus" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="rock-pi-4-plus" device_name="Radxa ROCK Pi 4B Plus" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="rock-pi-n10" device_name="Radxa ROCK Pi N10" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_11_0 device="sapphire" device_name="Rockchip Sapphire Board" %}
     </div>
 </div>
 
@@ -121,34 +119,34 @@ description: Rockchip based devices
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3288</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3288" arch=arch version=site.le_version_download_10_0 device="tinker" device_name="ASUS Tinker Board" %}
-        {% include dl_links.html project="RK3288" arch=arch version=site.le_version_download_10_0 device="miqi" device_name="Mqmaker MiQi" %}
+        {% include dl_links.html project="RK3288" arch=arm version=site.le_version_download_10_0 device="tinker" device_name="ASUS Tinker Board" %}
+        {% include dl_links.html project="RK3288" arch=arm version=site.le_version_download_10_0 device="miqi" device_name="Mqmaker MiQi" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3328</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_10_0 device="a1" device_name="Beelink A1 TV BOX" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_10_0 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_10_0 device="rock64" device_name="PINE64 ROCK64" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_10_0 device="rock64" device_name="Popcorn Hour Transformer" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_10_0 device="a1" device_name="Beelink A1 TV BOX" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_10_0 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_10_0 device="rock64" device_name="PINE64 ROCK64" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_10_0 device="rock64" device_name="Popcorn Hour Transformer" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3399</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="rock960" device_name="96rocks ROCK960" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="nanopc-t4" device_name="FriendlyARM NanoPC-T4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="nanopi-m4" device_name="FriendlyARM NanoPi M4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="hugsun-x99" device_name="Hugsun X99 TV BOX" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="khadas-edge" device_name="Khadas Edge" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="orangepi" device_name="Orange Pi RK3399" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="rockpro64" device_name="PINE64 RockPro64" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="roc-pc" device_name="ROC RK3399 PC" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_10_0 device="sapphire" device_name="Rockchip Sapphire Board" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="rock960" device_name="96rocks ROCK960" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="nanopc-t4" device_name="FriendlyARM NanoPC-T4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="nanopi-m4" device_name="FriendlyARM NanoPi M4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="hugsun-x99" device_name="Hugsun X99 TV BOX" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="khadas-edge" device_name="Khadas Edge" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="orangepi" device_name="Orange Pi RK3399" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="rockpro64" device_name="PINE64 RockPro64" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="roc-pc" device_name="ROC RK3399 PC" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_10_0 device="sapphire" device_name="Rockchip Sapphire Board" %}
     </div>
 </div>
 
@@ -167,30 +165,30 @@ description: Rockchip based devices
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3288</h5>
     <div class="card-body">
-        {% include dl_links.html project="TinkerBoard" arch=arch version=site.le_version_download_9_2 device="rk3288" device_name="ASUS Tinker Board" %}
-        {% include dl_links.html project="MiQi" arch=arch version=site.le_version_download_9_2 device="rk3288" device_name="Mqmaker MiQi" %} </div>
+        {% include dl_links.html project="TinkerBoard" arch=arm version=site.le_version_download_9_2 device="rk3288" device_name="ASUS Tinker Board" %}
+        {% include dl_links.html project="MiQi" arch=arm version=site.le_version_download_9_2 device="rk3288" device_name="Mqmaker MiQi" %} </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3328</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="box" device_name="Generic Rockchip Box" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="rock64" device_name="PINE64 ROCK64" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="rock64" device_name="Popcorn Hour Transformer" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="rockbox" device_name="Popcorn Hour RockBox" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="box-trn9" device_name="MVR9" %}
-        {% include dl_links.html project="RK3328" arch=arch version=site.le_version_download_9_2 device="box-z28" device_name="Z28" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="roc-cc" device_name="Firefly ROC-RK3328-CC" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="box" device_name="Generic Rockchip Box" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="rock64" device_name="PINE64 ROCK64" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="rock64" device_name="Popcorn Hour Transformer" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="rockbox" device_name="Popcorn Hour RockBox" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="box-trn9" device_name="MVR9" %}
+        {% include dl_links.html project="RK3328" arch=arm version=site.le_version_download_9_2 device="box-z28" device_name="Z28" %}
     </div>
 </div>
 
 <div class="card mb-4">
     <h5 class="card-header toc">Rockchip RK3399</h5>
     <div class="card-body">
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_9_2 device="rock960" device_name="96rocks ROCK960" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_9_2 device="khadas-edge" device_name="Khadas Edge" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_9_2 device="rockpro64" device_name="PINE64 RockPro64" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_9_2 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
-        {% include dl_links.html project="RK3399" arch=arch version=site.le_version_download_9_2 device="sapphire" device_name="Rockchip Sapphire Board" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_9_2 device="rock960" device_name="96rocks ROCK960" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_9_2 device="khadas-edge" device_name="Khadas Edge" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_9_2 device="rockpro64" device_name="PINE64 RockPro64" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_9_2 device="rock-pi-4" device_name="Radxa ROCK Pi 4" %}
+        {% include dl_links.html project="RK3399" arch=arm version=site.le_version_download_9_2 device="sapphire" device_name="Rockchip Sapphire Board" %}
     </div>
 </div>


### PR DESCRIPTION
LE11 and older correctly assume all ARM SoC boards are "arm" CPU arch but LE12 now ships "aarch64" images too so the templates need tweaking else the links are wrong. Also exclude WeTek Hub from LE11 as this has proven troublesome with some installs and LE12 because we stopped building it (due to same troubles).

Reported in https://forum.libreelec.tv/thread/28329-libreelec-omega-12-beta1/?postID=189976#post189976